### PR TITLE
Port to Humble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+config/yolo-v3-tiny/*
+!config/yolo-v3-tiny/params.yaml
+config/yolo-v7/*
+!config/yolo-v7/params.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
+config/yolo-v3/*
+!config/yolo-v3/params.yaml
 config/yolo-v3-tiny/*
 !config/yolo-v3-tiny/params.yaml
+config/yolo-v4/*
+!config/yolo-v4/params.yaml
+config/yolo-v4-tiny/*
+!config/yolo-v4-tiny/params.yaml
 config/yolo-v7/*
 !config/yolo-v7/params.yaml
+config/yolo-v7-tiny/*
+!config/yolo-v7-tiny/params.yaml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,6 @@ find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(vision_msgs REQUIRED)
 
-include_directories(
-  ${Darknet_INCLUDE_DIR}
-)
-link_libraries(Darknet::dark)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 add_library(openrobotics_darknet_ros SHARED
   src/detector_network.cpp
   src/parse.cpp)
@@ -35,6 +29,9 @@ ament_target_dependencies(openrobotics_darknet_ros
   cv_bridge
   sensor_msgs
   vision_msgs)
+target_link_libraries(openrobotics_darknet_ros Darknet::dark)
+# Necessary as Darknet currently does not install to ./install/darknet/libdarknet.so
+set_target_properties(openrobotics_darknet_ros PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 add_library(detector_node SHARED
   src/detector_node.cpp)
@@ -83,6 +80,7 @@ if (DOWNLOAD_YOLO_CONFIG)
 endif()
 
 install(DIRECTORY config/ launch/ DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY config/ DESTINATION share/${PROJECT_NAME}/config)
 install(DIRECTORY include/ DESTINATION include)
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(openrobotics_darknet_ros)
 
+option(DOWNLOAD_YOLO_CONFIG "Download YOLO configuration files" OFF)
+
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
@@ -75,6 +77,43 @@ install(TARGETS detector_node
 install(TARGETS detector_node_main
   DESTINATION lib/${PROJECT_NAME})
 
+if (DOWNLOAD_YOLO_CONFIG)
+  # Download weights for Yolo v3 and v7
+  # See https://pjreddie.com/darknet/yolo/
+  file(DOWNLOAD
+    https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/coco.names
+    SHOW_PROGRESS
+  )
+  file(DOWNLOAD
+    https://raw.githubusercontent.com/pjreddie/darknet/master/cfg/yolov3-tiny.cfg
+    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/yolov3-tiny.cfg
+    SHOW_PROGRESS
+  )
+  file(DOWNLOAD
+    https://pjreddie.com/media/files/yolov3-tiny.weights
+    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/yolov3-tiny.weights
+    SHOW_PROGRESS
+  )
+  # See https://github.com/AlexeyAB/darknet/issues/8595
+  file(DOWNLOAD
+    https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/coco.names
+    SHOW_PROGRESS
+  )
+  file(DOWNLOAD
+    https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov7.cfg
+    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/yolov7.cfg
+    SHOW_PROGRESS
+  )
+  file(DOWNLOAD
+    https://github.com/AlexeyAB/darknet/releases/download/yolov4/yolov7.weights
+    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/yolov7.weights
+    SHOW_PROGRESS
+  )
+endif()
+
+install(DIRECTORY config/ launch/ DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY include/ DESTINATION include)
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,40 +77,9 @@ install(TARGETS detector_node
 install(TARGETS detector_node_main
   DESTINATION lib/${PROJECT_NAME})
 
+# Download weights for Yolo v3, v4 and v7
 if (DOWNLOAD_YOLO_CONFIG)
-  # Download weights for Yolo v3 and v7
-  # See https://pjreddie.com/darknet/yolo/
-  file(DOWNLOAD
-    https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
-    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/coco.names
-    SHOW_PROGRESS
-  )
-  file(DOWNLOAD
-    https://raw.githubusercontent.com/pjreddie/darknet/master/cfg/yolov3-tiny.cfg
-    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/yolov3-tiny.cfg
-    SHOW_PROGRESS
-  )
-  file(DOWNLOAD
-    https://pjreddie.com/media/files/yolov3-tiny.weights
-    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/yolov3-tiny.weights
-    SHOW_PROGRESS
-  )
-  # See https://github.com/AlexeyAB/darknet/issues/8595
-  file(DOWNLOAD
-    https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
-    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/coco.names
-    SHOW_PROGRESS
-  )
-  file(DOWNLOAD
-    https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov7.cfg
-    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/yolov7.cfg
-    SHOW_PROGRESS
-  )
-  file(DOWNLOAD
-    https://github.com/AlexeyAB/darknet/releases/download/yolov4/yolov7.weights
-    ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/yolov7.weights
-    SHOW_PROGRESS
-  )
+  include(ConfigDownload.cmake)
 endif()
 
 install(DIRECTORY config/ launch/ DESTINATION share/${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,17 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(cv_bridge REQUIRED)
-find_package(darknet_vendor REQUIRED)
+find_package(Darknet REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(vision_msgs REQUIRED)
+
+include_directories(
+  ${Darknet_INCLUDE_DIR}
+)
+link_libraries(Darknet::dark)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 add_library(openrobotics_darknet_ros SHARED
   src/detector_network.cpp
@@ -25,7 +31,6 @@ target_include_directories(openrobotics_darknet_ros PUBLIC include)
 target_compile_definitions(openrobotics_darknet_ros PRIVATE "DARKNET_ROS_BUILDING_DLL")
 ament_target_dependencies(openrobotics_darknet_ros
   cv_bridge
-  darknet_vendor
   sensor_msgs
   vision_msgs)
 

--- a/ConfigDownload.cmake
+++ b/ConfigDownload.cmake
@@ -1,0 +1,103 @@
+# Download weights for Yolo v3, v4 and v7
+
+# Yolo v3
+# See https://pjreddie.com/darknet/yolo/
+file(DOWNLOAD
+  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3/coco.names
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+https://github.com/AlexeyAB/darknet/blob/master/cfg/yolov3.cfg
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3/yolov3.cfg
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+  https://pjreddie.com/media/files/yolov3.weights
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3/yolov3.weights
+  SHOW_PROGRESS
+)
+# Yolo v3 tiny
+file(DOWNLOAD
+  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/coco.names
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+  https://raw.githubusercontent.com/pjreddie/darknet/master/cfg/yolov3-tiny.cfg
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/yolov3-tiny.cfg
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+  https://pjreddie.com/media/files/yolov3-tiny.weights
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/yolov3-tiny.weights
+  SHOW_PROGRESS
+)
+
+# Yolo v4
+# See https://github.com/AlexeyAB/darknet#pre-trained-models
+file(DOWNLOAD
+  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4/coco.names
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov4.cfg
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4/yolov4.cfg
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+  https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v3_optimal/yolov4.weights
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4/yolov4.weights
+  SHOW_PROGRESS
+)
+# Yolo v4 tiny
+file(DOWNLOAD
+  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4-tiny/coco.names
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+  https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov4-tiny.cfg
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4-tiny/yolov4-tiny.cfg
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+  https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v4_pre/yolov4-tiny.weights
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4-tiny/yolov4-tiny.weights
+  SHOW_PROGRESS
+)
+
+# Yolo v7
+# See https://github.com/AlexeyAB/darknet/issues/8595
+file(DOWNLOAD
+  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/coco.names
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+  https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov7.cfg
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/yolov7.cfg
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+  https://github.com/AlexeyAB/darknet/releases/download/yolov4/yolov7.weights
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/yolov7.weights
+  SHOW_PROGRESS
+)
+# Yolo v7 tiny
+file(DOWNLOAD
+  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7-tiny/coco.names
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov7-tiny.cfg
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7-tiny/yolov7-tiny.cfg
+  SHOW_PROGRESS
+)
+file(DOWNLOAD
+  https://github.com/AlexeyAB/darknet/releases/download/yolov4/yolov7-tiny.weights
+  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7-tiny/yolov7-tiny.weights
+  SHOW_PROGRESS
+)

--- a/ConfigDownload.cmake
+++ b/ConfigDownload.cmake
@@ -4,33 +4,33 @@
 # See https://pjreddie.com/darknet/yolo/
 file(DOWNLOAD
   https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3/coco.names
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
 https://github.com/AlexeyAB/darknet/blob/master/cfg/yolov3.cfg
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3/yolov3.cfg
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3/yolov3.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
   https://pjreddie.com/media/files/yolov3.weights
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3/yolov3.weights
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3/yolov3.weights
   SHOW_PROGRESS
 )
 # Yolo v3 tiny
 file(DOWNLOAD
   https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/coco.names
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3-tiny/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
   https://raw.githubusercontent.com/pjreddie/darknet/master/cfg/yolov3-tiny.cfg
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/yolov3-tiny.cfg
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3-tiny/yolov3-tiny.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
   https://pjreddie.com/media/files/yolov3-tiny.weights
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v3-tiny/yolov3-tiny.weights
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3-tiny/yolov3-tiny.weights
   SHOW_PROGRESS
 )
 
@@ -38,33 +38,33 @@ file(DOWNLOAD
 # See https://github.com/AlexeyAB/darknet#pre-trained-models
 file(DOWNLOAD
   https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4/coco.names
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
 https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov4.cfg
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4/yolov4.cfg
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4/yolov4.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
   https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v3_optimal/yolov4.weights
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4/yolov4.weights
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4/yolov4.weights
   SHOW_PROGRESS
 )
 # Yolo v4 tiny
 file(DOWNLOAD
   https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4-tiny/coco.names
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4-tiny/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
   https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov4-tiny.cfg
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4-tiny/yolov4-tiny.cfg
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4-tiny/yolov4-tiny.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
   https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v4_pre/yolov4-tiny.weights
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v4-tiny/yolov4-tiny.weights
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4-tiny/yolov4-tiny.weights
   SHOW_PROGRESS
 )
 
@@ -72,32 +72,34 @@ file(DOWNLOAD
 # See https://github.com/AlexeyAB/darknet/issues/8595
 file(DOWNLOAD
   https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/coco.names
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
   https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov7.cfg
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/yolov7.cfg
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7/yolov7.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
   https://github.com/AlexeyAB/darknet/releases/download/yolov4/yolov7.weights
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7/yolov7.weights
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7/yolov7.weights
   SHOW_PROGRESS
 )
 # Yolo v7 tiny
 file(DOWNLOAD
   https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7-tiny/coco.names
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7-tiny/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
 https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov7-tiny.cfg
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7-tiny/yolov7-tiny.cfg
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7-tiny/yolov7-tiny.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
   https://github.com/AlexeyAB/darknet/releases/download/yolov4/yolov7-tiny.weights
-  ${CMAKE_CURRENT_SOURCE_DIR}/config/yolo-v7-tiny/yolov7-tiny.weights
+  ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7-tiny/yolov7-tiny.weights
   SHOW_PROGRESS
 )
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/config/ DESTINATION share/${PROJECT_NAME}/config/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Robotics Darknet ROS
 
-This is a ROS 2 wrapper around [darknet](https://pjreddie.com/darknet), an open source neural network framework.
+This is a **ROS 2 wrapper around [darknet](https://pjreddie.com/darknet)**, an open source neural network framework.
 
 ![Example image with bounding boxes created using darknet and the yolov3-tiny network](doc/example_darknet_yolov3-tiny.png)
 
@@ -24,25 +24,37 @@ This node can run **object detectors** like [YOLO v3](https://pjreddie.com/darkn
 * `detection.threshold` - Minimum probability of a detection to be published
 * `detection.nms_threshold` - Non-maximal Suppression threshold - controls filtering of overlapping boxes
 
+## Dependencies
+
+This package depends on [darknet](https://github.com/AlexeyAB/darknet). If you can't use CUDA but want to use your CPU instead make sure to build it with the flag `-DENABLE_CUDA=OFF` and potentially also disabling multi-threading with `-DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=TRUE`.
+
 ### Launching
 
-When compiling the package with
+Compiling this package with
 
 ```bash
-colcon build --cmake-args -DDOWNLOAD_YOLO_CONFIG=ON
+$ colcon build --cmake-args -DDOWNLOAD_YOLO_CONFIG=ON
 ```
 
-CMake will download the pretrained YOLO v3 and v7 configuration files to the `config` folder.
+will automatically download the pretrained YOLO v3, v4 and v7 configuration files.
 
-Alternatively can train YOLO to detect custom objects like described [here](https://github.com/AlexeyAB/darknet#how-to-train-tiny-yolo-to-detect-your-custom-objects) and save the following as `detector_node_params.yaml`:
+You can then launch the detector node with
+
+```bash
+$ ros2 launch openrobotics_darknet_ros detector_launch.py rgb_image:=/topic
+```
+
+optionally supplying a desired parameter file `detector_parameters:=path/to/detector_node_params.yaml`.
+
+You can also train YOLO to detect custom objects like described [here](https://github.com/AlexeyAB/darknet#how-to-train-tiny-yolo-to-detect-your-custom-objects) and create the following as `detector_node_params.yaml`:
 
 ```yaml
-detector_node:
+/**:
   ros__parameters:
     network:
-      config: "./yolov3-tiny.cfg"
-      weights: "./yolov3-tiny.weights"
-      class_names: "./coco.names"
+      config: "./your-yolo-config.cfg"
+      weights: "./your-yolo-weights.weights"
+      class_names: "./your-cocos.names"
     detection:
       threshold: 0.25
       nms_threshold: 0.45
@@ -50,15 +62,13 @@ detector_node:
 
 Finally you can run the detector node with
 
-```
-ros2 run openrobotics_darknet_ros detector_node --ros-args --params-file /your/path/to/detector_node_params.yaml
+```bash
+$ ros2 run openrobotics_darknet_ros detector_node --ros-args --params-file path/to/detector_node_params.yaml
 ```
 
-and publish images on `~/images` to get the node to detect objects.
+and publish images on `~/images` to get the node to detect objects. You can also manually remap an external topic to the `~/images` topic with:
 
-You can also manually remap an external topic to the `~/images` topic with:
-
-```
-ros2 run openrobotics_darknet_ros detector_node --ros-args --params-file /world_model_ws/src/detector_node_params.yaml -r '~/images:=/your/camera/topic'
+```bash
+$ ros2 run openrobotics_darknet_ros detector_node --ros-args --params-file path/to/detector_node_params.yaml -r '~/images:=/your/camera/topic'
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a ROS 2 wrapper around [darknet](https://pjreddie.com/darknet), an open 
 
 ## DetectorNode
 
-This node can run object detectors like [YOLOv3](https://pjreddie.com/darknet/yolo/) on images.
+This node can run **object detectors** like [YOLO v3](https://pjreddie.com/darknet/yolo/) or [YOLO v7](https://github.com/WongKinYiu/yolov7) on images and video streams.
 
 ### Subscribers
 
@@ -24,17 +24,17 @@ This node can run object detectors like [YOLOv3](https://pjreddie.com/darknet/yo
 * `detection.threshold` - Minimum probability of a detection to be published
 * `detection.nms_threshold` - Non-maximal Suppression threshold - controls filtering of overlapping boxes
 
-### Example
+### Launching
 
-Download `YOLOv3-tiny`.
+When compiling the package with
 
-```
-wget https://raw.githubusercontent.com/pjreddie/darknet/f86901f6177dfc6116360a13cc06ab680e0c86b0/cfg/yolov3-tiny.cfg
-wget https://pjreddie.com/media/files/yolov3-tiny.weights
-wget https://raw.githubusercontent.com/pjreddie/darknet/c6afc7ff1499fbbe64069e1843d7929bd7ae2eaa/data/coco.names
+```bash
+colcon build --cmake-args -DDOWNLOAD_YOLO_CONFIG=ON
 ```
 
-Save the following as `detector_node_params.yaml`
+CMake will download the pretrained YOLO v3 and v7 configuration files to the `config` folder.
+
+Alternatively can train YOLO to detect custom objects like described [here](https://github.com/AlexeyAB/darknet#how-to-train-tiny-yolo-to-detect-your-custom-objects) and save the following as `detector_node_params.yaml`:
 
 ```yaml
 detector_node:
@@ -48,13 +48,13 @@ detector_node:
       nms_threshold: 0.45
 ```
 
-Then run the node.
+Finally you can run the detector node with
 
 ```
 ros2 run openrobotics_darknet_ros detector_node --ros-args --params-file /your/path/to/detector_node_params.yaml
 ```
 
-The node is now running. Publish images on `~/images` to get the node to detect objects.
+and publish images on `~/images` to get the node to detect objects.
 
 You can also manually remap an external topic to the `~/images` topic with:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ wget https://raw.githubusercontent.com/pjreddie/darknet/c6afc7ff1499fbbe64069e18
 Save the following as `detector_node_params.yaml`
 
 ```yaml
-/**:
+detector_node:
   ros__parameters:
     network:
       config: "./yolov3-tiny.cfg"
@@ -51,8 +51,14 @@ Save the following as `detector_node_params.yaml`
 Then run the node.
 
 ```
-ros2 run openrobotics_darknet_ros detector_node __params:=detector_node_params.yaml
+ros2 run openrobotics_darknet_ros detector_node --ros-args --params-file /your/path/to/detector_node_params.yaml
 ```
 
-The node is now running.
-Publish images on `~/images` to get the node to detect objects.
+The node is now running. Publish images on `~/images` to get the node to detect objects.
+
+You can also manually remap an external topic to the `~/images` topic with:
+
+```
+ros2 run openrobotics_darknet_ros detector_node --ros-args --params-file /world_model_ws/src/detector_node_params.yaml -r '~/images:=/your/camera/topic'
+```
+

--- a/config/yolo-v3-tiny/params.yaml
+++ b/config/yolo-v3-tiny/params.yaml
@@ -1,9 +1,9 @@
-detector_node:
+/**:
   ros__parameters:
     network:
-      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3-tiny/yolov3-tiny.cfg"
-      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3-tiny/yolov3-tiny.weights"
-      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3-tiny/coco.names"
+      config: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v3-tiny/yolov3-tiny.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v3-tiny/yolov3-tiny.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v3-tiny/coco.names"
     detection:
       threshold: 0.25
       nms_threshold: 0.45

--- a/config/yolo-v3-tiny/params.yaml
+++ b/config/yolo-v3-tiny/params.yaml
@@ -1,0 +1,9 @@
+detector_node:
+  ros__parameters:
+    network:
+      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3-tiny/yolov3-tiny.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3-tiny/yolov3-tiny.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3-tiny/coco.names"
+    detection:
+      threshold: 0.25
+      nms_threshold: 0.45

--- a/config/yolo-v3/params.yaml
+++ b/config/yolo-v3/params.yaml
@@ -1,9 +1,9 @@
-detector_node:
+/**:
   ros__parameters:
     network:
-      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3/yolov3.cfg"
-      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3/yolov3.weights"
-      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3/coco.names"
+      config: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v3/yolov3.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v3/yolov3.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v3/coco.names"
     detection:
       threshold: 0.25
       nms_threshold: 0.45

--- a/config/yolo-v3/params.yaml
+++ b/config/yolo-v3/params.yaml
@@ -1,0 +1,9 @@
+detector_node:
+  ros__parameters:
+    network:
+      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3/yolov3.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3/yolov3.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v3/coco.names"
+    detection:
+      threshold: 0.25
+      nms_threshold: 0.45

--- a/config/yolo-v4-tiny/params.yaml
+++ b/config/yolo-v4-tiny/params.yaml
@@ -1,0 +1,9 @@
+detector_node:
+  ros__parameters:
+    network:
+      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4-tiny/yolov4-tiny.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4-tiny/yolov4-tiny.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4-tiny/coco.names"
+    detection:
+      threshold: 0.25
+      nms_threshold: 0.45

--- a/config/yolo-v4-tiny/params.yaml
+++ b/config/yolo-v4-tiny/params.yaml
@@ -1,9 +1,9 @@
-detector_node:
+/**:
   ros__parameters:
     network:
-      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4-tiny/yolov4-tiny.cfg"
-      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4-tiny/yolov4-tiny.weights"
-      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4-tiny/coco.names"
+      config: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v4-tiny/yolov4-tiny.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v4-tiny/yolov4-tiny.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v4-tiny/coco.names"
     detection:
       threshold: 0.25
       nms_threshold: 0.45

--- a/config/yolo-v4/params.yaml
+++ b/config/yolo-v4/params.yaml
@@ -1,0 +1,9 @@
+detector_node:
+  ros__parameters:
+    network:
+      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4/yolov4.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4/yolov4.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4/coco.names"
+    detection:
+      threshold: 0.25
+      nms_threshold: 0.45

--- a/config/yolo-v4/params.yaml
+++ b/config/yolo-v4/params.yaml
@@ -1,9 +1,9 @@
-detector_node:
+/**:
   ros__parameters:
     network:
-      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4/yolov4.cfg"
-      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4/yolov4.weights"
-      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v4/coco.names"
+      config: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v4/yolov4.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v4/yolov4.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v4/coco.names"
     detection:
       threshold: 0.25
       nms_threshold: 0.45

--- a/config/yolo-v7-tiny/params.yaml
+++ b/config/yolo-v7-tiny/params.yaml
@@ -1,9 +1,9 @@
-detector_node:
+/**:
   ros__parameters:
     network:
-      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7-tiny/yolov7-tiny.cfg"
-      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7-tiny/yolov7-tiny.weights"
-      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7-tiny/coco.names"
+      config: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v7-tiny/yolov7-tiny.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v7-tiny/yolov7-tiny.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v7-tiny/coco.names"
     detection:
       threshold: 0.25
       nms_threshold: 0.45

--- a/config/yolo-v7-tiny/params.yaml
+++ b/config/yolo-v7-tiny/params.yaml
@@ -1,0 +1,9 @@
+detector_node:
+  ros__parameters:
+    network:
+      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7-tiny/yolov7-tiny.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7-tiny/yolov7-tiny.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7-tiny/coco.names"
+    detection:
+      threshold: 0.25
+      nms_threshold: 0.45

--- a/config/yolo-v7/params.yaml
+++ b/config/yolo-v7/params.yaml
@@ -1,9 +1,9 @@
-detector_node:
+/**:
   ros__parameters:
     network:
-      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7/yolov7.cfg"
-      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7/yolov7.weights"
-      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7/coco.names"
+      config: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v7/yolov7.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v7/yolov7.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/config/yolo-v7/coco.names"
     detection:
       threshold: 0.25
       nms_threshold: 0.45

--- a/config/yolo-v7/params.yaml
+++ b/config/yolo-v7/params.yaml
@@ -1,0 +1,9 @@
+detector_node:
+  ros__parameters:
+    network:
+      config: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7/yolov7.cfg"
+      weights: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7/yolov7.weights"
+      class_names: "$(find-pkg-share openrobotics_darknet_ros)/yolo-v7/coco.names"
+    detection:
+      threshold: 0.25
+      nms_threshold: 0.45

--- a/include/openrobotics_darknet_ros/detector_node.hpp
+++ b/include/openrobotics_darknet_ros/detector_node.hpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "rclcpp/node.hpp"
+#include "rclcpp/node_interfaces/node_parameters_interface.hpp"
 #include "openrobotics_darknet_ros/visibility_node.hpp"
 
 
@@ -41,6 +42,7 @@ public:
 
 private:
   std::unique_ptr<DetectorNodePrivate> impl_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 };
 }  // namespace darknet_ros
 }  // namespace openrobotics

--- a/launch/detector_launch.py
+++ b/launch/detector_launch.py
@@ -15,7 +15,7 @@ def generate_launch_description():
 
     default_detector_parameter_file = os.path.join(
         get_package_share_directory('openrobotics_darknet_ros'),
-        'yolo-v7',
+        'yolo-v7-tiny',
         'params.yaml'
     )
     detector_parameters_cmd = DeclareLaunchArgument(

--- a/launch/detector_launch.py
+++ b/launch/detector_launch.py
@@ -11,6 +11,7 @@ from launch_ros.parameter_descriptions import ParameterFile
 def generate_launch_description():
     detector_parameters_file = LaunchConfiguration('detector_parameters')
     rgb_image_topic = LaunchConfiguration('rgb_image')
+    detections_topic = LaunchConfiguration('detections')
 
     default_detector_parameter_file = os.path.join(
         get_package_share_directory('openrobotics_darknet_ros'),
@@ -26,13 +27,19 @@ def generate_launch_description():
         'rgb_image',
         description='RGB image that should be used for object detection with YOLO'
     )
+    detections_topic_cmd = DeclareLaunchArgument(
+        'detections',
+        default_value='~/detections',
+        description='Detections containing the bounding boxes of objects to be considered'
+    )
 
     yolo_detector_node = Node(
         package='openrobotics_darknet_ros',
         executable='detector_node',
         name='detector_node',
         remappings=[
-            ('~/images', rgb_image_topic)
+            ('~/images', rgb_image_topic),
+            ('~/detections', detections_topic)
         ],
         parameters = [ParameterFile(detector_parameters_file, allow_substs=True)]
     )
@@ -40,5 +47,6 @@ def generate_launch_description():
     ld = LaunchDescription()
     ld.add_action(detector_parameters_cmd)
     ld.add_action(rgb_image_cmd)
+    ld.add_action(detections_topic_cmd)
     ld.add_action(yolo_detector_node)
     return ld

--- a/launch/detector_launch.py
+++ b/launch/detector_launch.py
@@ -1,0 +1,44 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterFile
+
+
+def generate_launch_description():
+    detector_parameters_file = LaunchConfiguration('detector_parameters')
+    rgb_image_topic = LaunchConfiguration('rgb_image')
+
+    default_detector_parameter_file = os.path.join(
+        get_package_share_directory('openrobotics_darknet_ros'),
+        'yolo-v7',
+        'params.yaml'
+    )
+    detector_parameters_cmd = DeclareLaunchArgument(
+        'detector_parameters',
+        default_value=default_detector_parameter_file,
+        description='YOLO object detection configuration file'
+    )
+    rgb_image_cmd = DeclareLaunchArgument(
+        'rgb_image',
+        description='RGB image that should be used for object detection with YOLO'
+    )
+
+    yolo_detector_node = Node(
+        package='openrobotics_darknet_ros',
+        executable='detector_node',
+        name='detector_node',
+        remappings=[
+            ('~/images', rgb_image_topic)
+        ],
+        parameters = [ParameterFile(detector_parameters_file, allow_substs=True)]
+    )
+
+    ld = LaunchDescription()
+    ld.add_action(detector_parameters_cmd)
+    ld.add_action(rgb_image_cmd)
+    ld.add_action(yolo_detector_node)
+    return ld

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>cv_bridge</depend>
-  <depend>darknet_vendor</depend>
+  <depend>darknet</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>

--- a/src/darknet_detections.hpp
+++ b/src/darknet_detections.hpp
@@ -15,7 +15,7 @@
 #ifndef DARKNET_DETECTIONS_HPP_
 #define DARKNET_DETECTIONS_HPP_
 
-#include <darknet_vendor/darknet_vendor.h>
+#include <darknet.h>
 
 namespace openrobotics
 {

--- a/src/darknet_image.hpp
+++ b/src/darknet_image.hpp
@@ -15,7 +15,7 @@
 #ifndef DARKNET_IMAGE_HPP_
 #define DARKNET_IMAGE_HPP_
 
-#include <darknet_vendor/darknet_vendor.h>
+#include <darknet.h>
 #include <cv_bridge/cv_bridge.h>
 
 #include <memory>

--- a/src/detector_node.cpp
+++ b/src/detector_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <darknet_vendor/darknet_vendor.h>
+#include <darknet.h>
 
 #include <memory>
 #include <string>
@@ -94,30 +94,26 @@ DetectorNode::DetectorNode(rclcpp::NodeOptions options)
   network_cfg_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
   network_cfg_desc.read_only = true;
   network_cfg_desc.name = "network.config";
-  const std::string network_config_path = declare_parameter(
-    network_cfg_desc.name,
-    rclcpp::ParameterValue(),
-    network_cfg_desc).get<std::string>();
+  network_cfg_desc.dynamic_typing = true;
+  const std::string network_config_path = declare_parameter<std::string>(
+    network_cfg_desc.name);
 
   rcl_interfaces::msg::ParameterDescriptor network_weights_desc;
   network_weights_desc.description = "Path to file describing network weights";
   network_weights_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
   network_weights_desc.read_only = true;
   network_weights_desc.name = "network.weights";
-  const std::string network_weights_path = declare_parameter(
-    network_weights_desc.name,
-    rclcpp::ParameterValue(),
-    network_weights_desc).get<std::string>();
+  const std::string network_weights_path = declare_parameter<std::string>(
+    network_weights_desc.name);
 
   rcl_interfaces::msg::ParameterDescriptor network_class_names_desc;
   network_class_names_desc.description = "Path to file with class names (one per line)";
   network_class_names_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
   network_class_names_desc.read_only = true;
   network_class_names_desc.name = "network.class_names";
-  const std::string network_class_names_path = declare_parameter(
-    network_class_names_desc.name,
-    rclcpp::ParameterValue(),
-    network_class_names_desc).get<std::string>();
+  network_class_names_desc.dynamic_typing = true;
+  const std::string network_class_names_path = declare_parameter<std::string>(
+    network_class_names_desc.name);
 
   impl_->threshold_desc_.description = "Minimum detection confidence [0.0, 1.0]";
   impl_->threshold_desc_.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
@@ -136,7 +132,7 @@ DetectorNode::DetectorNode(rclcpp::NodeOptions options)
     rclcpp::ParameterValue(impl_->nms_threshold_),
     impl_->nms_threshold_desc_).get<double>();
 
-  set_on_parameters_set_callback(
+  add_on_set_parameters_callback(
     std::bind(&DetectorNodePrivate::on_parameters_change, &*impl_, std::placeholders::_1));
 
   // TODO(sloretz) raise if user tried to initialize node with undeclared parameters

--- a/src/detector_node.cpp
+++ b/src/detector_node.cpp
@@ -132,7 +132,7 @@ DetectorNode::DetectorNode(rclcpp::NodeOptions options)
     rclcpp::ParameterValue(impl_->nms_threshold_),
     impl_->nms_threshold_desc_).get<double>();
 
-  add_on_set_parameters_callback(
+  param_callback_handle_ = add_on_set_parameters_callback(
     std::bind(&DetectorNodePrivate::on_parameters_change, &*impl_, std::placeholders::_1));
 
   // TODO(sloretz) raise if user tried to initialize node with undeclared parameters


### PR DESCRIPTION
This pull request ports the Darknet ROS to **ROS 2 Humble** adding several improvements, namely:
- **Elimination of the Darknet vendor** due to the two pull-requests that got approved on Darknet directly https://github.com/AlexeyAB/darknet/pull/8782 and https://github.com/AlexeyAB/darknet/pull/8783
- Porting of the changes in the **`vision_msgs`**, see also https://github.com/ros2/openrobotics_darknet_ros/issues/9
- **Automatic download of Yolo configuration files for Yolo V3, V4, V7** and their tiny variants when building with `DOWNLOAD_YOLO_CONFIG=ON` and a corresponding launch file that allows to switch easily between them.