### PR TITLE
Switch to hank-ai darknet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(cv_bridge REQUIRED)
-find_package(Darknet REQUIRED)
+find_library(Darknet darknet REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -29,7 +29,7 @@ ament_target_dependencies(openrobotics_darknet_ros
   cv_bridge
   sensor_msgs
   vision_msgs)
-target_link_libraries(openrobotics_darknet_ros Darknet::dark)
+target_link_libraries(openrobotics_darknet_ros "${Darknet}")
 # Necessary as Darknet currently does not install to ./install/darknet/libdarknet.so
 set_target_properties(openrobotics_darknet_ros PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 

--- a/ConfigDownload.cmake
+++ b/ConfigDownload.cmake
@@ -3,33 +3,33 @@
 # Yolo v3
 # See https://pjreddie.com/darknet/yolo/
 file(DOWNLOAD
-  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfg/coco.names
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-https://github.com/AlexeyAB/darknet/blob/master/cfg/yolov3.cfg
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfgyolov3.cfg
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3/yolov3.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-  https://pjreddie.com/media/files/yolov3.weights
+  hhttps://github.com/hank-ai/darknet/releases/download/v2.0/yolov3.weights
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3/yolov3.weights
   SHOW_PROGRESS
 )
 # Yolo v3 tiny
 file(DOWNLOAD
-  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfg/coco.names
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3-tiny/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-  https://raw.githubusercontent.com/pjreddie/darknet/master/cfg/yolov3-tiny.cfg
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfgyolov3-tiny.cfg
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3-tiny/yolov3-tiny.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-  https://pjreddie.com/media/files/yolov3-tiny.weights
+  https://github.com/hank-ai/darknet/releases/download/v2.0/yolov3-tiny.weights
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v3-tiny/yolov3-tiny.weights
   SHOW_PROGRESS
 )
@@ -37,33 +37,34 @@ file(DOWNLOAD
 # Yolo v4
 # See https://github.com/AlexeyAB/darknet#pre-trained-models
 file(DOWNLOAD
-  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfg/coco.names
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov4.cfg
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfgyolov4.cfg
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4/yolov4.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-  https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v3_optimal/yolov4.weights
+  https://github.com/hank-ai/darknet/releases/download/v2.0/yolov4.weights
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4/yolov4.weights
   SHOW_PROGRESS
 )
+
 # Yolo v4 tiny
 file(DOWNLOAD
-  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfg/coco.names
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4-tiny/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-  https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov4-tiny.cfg
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfgyolov4-tiny.cfg
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4-tiny/yolov4-tiny.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-  https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v4_pre/yolov4-tiny.weights
+  https://github.com/hank-ai/darknet/releases/download/v2.0/yolov4-tiny.weights
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v4-tiny/yolov4-tiny.weights
   SHOW_PROGRESS
 )
@@ -71,33 +72,33 @@ file(DOWNLOAD
 # Yolo v7
 # See https://github.com/AlexeyAB/darknet/issues/8595
 file(DOWNLOAD
-  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfg/coco.names
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-  https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov7.cfg
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfgyolov7.cfg
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7/yolov7.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-  https://github.com/AlexeyAB/darknet/releases/download/yolov4/yolov7.weights
+  https://github.com/hank-ai/darknet/releases/download/v2.0/yolov7.weights
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7/yolov7.weights
   SHOW_PROGRESS
 )
 # Yolo v7 tiny
 file(DOWNLOAD
-  https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfg/coco.names
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7-tiny/coco.names
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov7-tiny.cfg
+  https://raw.githubusercontent.com/hank-ai/darknet/master/cfg/yolov7-tiny.cfg
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7-tiny/yolov7-tiny.cfg
   SHOW_PROGRESS
 )
 file(DOWNLOAD
-  https://github.com/AlexeyAB/darknet/releases/download/yolov4/yolov7-tiny.weights
+  https://github.com/hank-ai/darknet/releases/download/v2.0/yolov7-tiny.weights
   ${CMAKE_CURRENT_BINARY_DIR}/config/yolo-v7-tiny/yolov7-tiny.weights
   SHOW_PROGRESS
 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Robotics Darknet ROS
 
-This is a **ROS 2 wrapper around [darknet](https://pjreddie.com/darknet)**, an open source neural network framework.
+This is a **ROS 2 wrapper around [darknet](https://github.com/hank-ai/darknet)**, an open source neural network framework.
 
 ![Example image with bounding boxes created using darknet and the yolov3-tiny network](doc/example_darknet_yolov3-tiny.png)
 

--- a/src/detector_network.cpp
+++ b/src/detector_network.cpp
@@ -72,7 +72,7 @@ DetectorNetwork::DetectorNetwork(
   }
 
   // what does this call do? https://github.com/stephanecharette/DarkHelp/blob/master/src-lib/DarkHelpNN.cpp#L202
-	calculate_binary_weights(*impl_->network_);
+  calculate_binary_weights(*impl_->network_);
 
   const int num_classes_int = impl_->network_->layers[impl_->network_->n - 1].classes;
   if (num_classes_int <= 0) {

--- a/src/detector_network.cpp
+++ b/src/detector_network.cpp
@@ -80,8 +80,9 @@ DetectorNetwork::DetectorNetwork(
   }
 
   // TODO(sloretz) what is this and why do examples set it?
-  const int batch = 1;
-  set_batch_network(impl_->network_, batch);
+  // TODO(bracoe) Check what this did. Has been moved to private API in darknet but works without it.
+  //const int batch = 1;
+  //set_batch_network(impl_->network_, batch);
 
   const int num_classes_int = impl_->network_->layers[impl_->network_->n - 1].classes;
   if (num_classes_int <= 0) {


### PR DESCRIPTION
Hello,

I never really got [AlexeyAB/darknet](https://github.com/AlexeyAB/darknet) to compile and it looks like [hank-ai/darknet](https://github.com/hank-ai/darknet) are maintaining darknet now. Some changes are needed to make this wrapper work when following the instructions in their [readme](https://github.com/hank-ai/darknet/blob/master/README.md). 

@2b-t does this break things for you?